### PR TITLE
feat: add language switcher with French, Arabic and Spanish translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     <!-- Titre et description génériques (fallback) -->
-    <title>Les Laboratoires Zeroual</title>
-    <meta name="description" content="Une plateforme web moderne pour présenter les services de laboratoires médicaux." />
+    <title data-i18n="title"></title>
+    <meta
+      name="description"
+      content="Une plateforme web moderne pour présenter les services de laboratoires médicaux."
+    />
 
     <!-- Favicon -->
     <link rel="preload" href="/fonts/myfont.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
@@ -23,29 +26,71 @@
 
     <!-- Canonical URL de base -->
     <link rel="canonical" href="https://leslaboratoireszeroual.ma" />
+
+    <style>
+      .language-switcher {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+        z-index: 1000;
+      }
+
+      html[dir="rtl"] body {
+        direction: rtl;
+        text-align: right;
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div class="language-switcher">
+      <select id="languageSwitcher">
+        <option value="fr">Français</option>
+        <option value="ar">العربية</option>
+        <option value="es">Español</option>
+      </select>
+    </div>
 
-    <!-- Ici tu ajoutes l'élément Google Translate -->
-    <div id="google_translate_element" style="position:fixed; bottom:10px; right:10px; z-index:999;"></div>
+    <h1 data-i18n="title"></h1>
+    <p data-i18n="welcome"></p>
+
+    <div id="root"></div>
 
     <script type="module" src="/src/main.tsx"></script>
 
-    <!-- Google Translate Script -->
-    <script type="text/javascript">
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement(
-          {
-            pageLanguage: 'fr', // Langue par défaut de ton site
-            includedLanguages: 'en,es,ar', // Langues que tu veux proposer
-            layout: google.translate.TranslateElement.InlineLayout.SIMPLE
-          },
-          'google_translate_element'
-        );
+    <script>
+      const translations = {
+        fr: {
+          title: 'Les Laboratoires Zeroual',
+          welcome: 'Bienvenue sur notre site'
+        },
+        ar: {
+          title: 'مختبرات زروال',
+          welcome: 'مرحبًا بكم في موقعنا'
+        },
+        es: {
+          title: 'Los Laboratorios Zeroual',
+          welcome: 'Bienvenido a nuestro sitio'
+        }
+      };
+
+      const switcher = document.getElementById('languageSwitcher');
+
+      function updateContent(lang) {
+        const elements = document.querySelectorAll('[data-i18n]');
+        elements.forEach((el) => {
+          const key = el.getAttribute('data-i18n');
+          el.textContent = translations[lang][key] || '';
+        });
+        document.documentElement.lang = lang;
+        document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
       }
+
+      switcher.addEventListener('change', (e) => {
+        updateContent(e.target.value);
+      });
+
+      updateContent('fr');
     </script>
-    <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 
     <!-- FontAwesome -->
     <script src="https://kit.fontawesome.com/TON_KIT.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add language selector for French, Arabic and Spanish
- dynamically translate page content and adjust RTL direction

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in services/payloadApi* files)


------
https://chatgpt.com/codex/tasks/task_e_68b6f57081c0832b80ee45bbeb07dc00